### PR TITLE
Hardcode images for regions

### DIFF
--- a/components/regions.js
+++ b/components/regions.js
@@ -1,18 +1,7 @@
+import { regions } from '../lib/regions.json'
 import { Grid, Card, Heading } from 'theme-ui'
 import { kebabCase, snakeCase, startCase } from 'lodash'
 import Link from 'next/link'
-
-let photoSrc = q =>
-  `https://source.unsplash.com/random/512x256/?${snakeCase(q)}`
-let regions = [
-  'Los Angeles',
-  'Chicago',
-  'New York',
-  'the Bay Area',
-  'the USA',
-  'Canada',
-  'India'
-]
 
 export default ({ showAll = false, sx = {} }) => (
   <Grid
@@ -52,7 +41,7 @@ export default ({ showAll = false, sx = {} }) => (
         </Card>
       </Link>
     )}
-    {regions.map(name => (
+    {Object.entries(regions).map(([name, url]) => (
       <Link
         href={`/list-of-hackathons-in-${kebabCase(name)}`}
         passHref
@@ -63,7 +52,7 @@ export default ({ showAll = false, sx = {} }) => (
           variant="event"
           style={{
             backgroundImage: `linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.375) 75%),
-              url(${photoSrc(name)})`
+              url(${url})`
           }}
         >
           <Heading as="h3" sx={{ fontSize: 3 }}>

--- a/lib/regions.json
+++ b/lib/regions.json
@@ -1,11 +1,11 @@
 {
   "regions": {
-    "Los Angeles": "https://images.unsplash.com/photo-1523595857-fe9ee689f76f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2467&q=80",
-    "Chicago": "https://images.unsplash.com/photo-1494522855154-9297ac14b55f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1500&q=80",
-    "New York": "https://images.unsplash.com/photo-1562961857-b1ba8f9dbd5f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1520&q=80",
-    "the Bay Area": "https://images.unsplash.com/photo-1501196788499-459dbea97736?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1500&q=80",
-    "the USA": "https://www.nps.gov/yose/planyourvisit/images/20170618_155330.jpg?maxwidth=1200&maxheight=1200&autorotate=false",
-    "Canada": "https://images.unsplash.com/photo-1479854851860-18d97e109331?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjExMDk0fQ&auto=format&fit=crop&w=1344&q=80",
-    "India": "https://images.unsplash.com/photo-1564507592333-c60657eea523?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1502&q=80"
+    "Los Angeles": "https://images.unsplash.com/photo-1523595857-fe9ee689f76f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=822&q=80",
+    "Chicago": "https://images.unsplash.com/photo-1494522855154-9297ac14b55f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q80",
+    "New York": "https://images.unsplash.com/photo-1562961857-b1ba8f9dbd5f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=506&q=80",
+    "the Bay Area": "https://images.unsplash.com/photo-1501196788499-459dbea97736?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=80",
+    "the USA": "https://www.nps.gov/yose/planyourvisit/images/20170618_155330.jpg?maxwidth=400&maxheight=400&autorotate=false",
+    "Canada": "https://images.unsplash.com/photo-1479854851860-18d97e109331?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjExMDk0fQ&auto=format&fit=crop&w=448&q=80",
+    "India": "https://images.unsplash.com/photo-1564507592333-c60657eea523?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=80"
   }
 }

--- a/lib/regions.json
+++ b/lib/regions.json
@@ -1,11 +1,11 @@
 {
   "regions": {
-    "Los Angeles": "https://images.unsplash.com/photo-1523595857-fe9ee689f76f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=822&q=80",
-    "Chicago": "https://images.unsplash.com/photo-1494522855154-9297ac14b55f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q80",
-    "New York": "https://images.unsplash.com/photo-1562961857-b1ba8f9dbd5f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=506&q=80",
-    "the Bay Area": "https://images.unsplash.com/photo-1501196788499-459dbea97736?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=80",
-    "the USA": "https://www.nps.gov/yose/planyourvisit/images/20170618_155330.jpg?maxwidth=400&maxheight=400&autorotate=false",
-    "Canada": "https://images.unsplash.com/photo-1479854851860-18d97e109331?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjExMDk0fQ&auto=format&fit=crop&w=448&q=80",
-    "India": "https://images.unsplash.com/photo-1564507592333-c60657eea523?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=80"
+    "Los Angeles": "https://images.unsplash.com/photo-1523595857-fe9ee689f76f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=512&q=80",
+    "Chicago": "https://images.unsplash.com/photo-1494522855154-9297ac14b55f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=512&q=80",
+    "New York": "https://images.unsplash.com/photo-1562961857-b1ba8f9dbd5f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=512&q=80",
+    "the Bay Area": "https://images.unsplash.com/photo-1501196788499-459dbea97736?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=512&q=80",
+    "the USA": "https://www.nps.gov/yose/planyourvisit/images/20170618_155330.jpg?maxwidth=512&maxheight=400&autorotate=false",
+    "Canada": "https://images.unsplash.com/photo-1479854851860-18d97e109331?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjExMDk0fQ&auto=format&fit=crop&w=512&q=80",
+    "India": "https://images.unsplash.com/photo-1564507592333-c60657eea523?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=512&q=80"
   }
 }

--- a/lib/regions.json
+++ b/lib/regions.json
@@ -1,0 +1,11 @@
+{
+  "regions": {
+    "Los Angeles": "https://images.unsplash.com/photo-1523595857-fe9ee689f76f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2467&q=80",
+    "Chicago": "https://images.unsplash.com/photo-1494522855154-9297ac14b55f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1500&q=80",
+    "New York": "https://images.unsplash.com/photo-1562961857-b1ba8f9dbd5f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1520&q=80",
+    "the Bay Area": "https://images.unsplash.com/photo-1501196788499-459dbea97736?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1500&q=80",
+    "the USA": "https://www.nps.gov/yose/planyourvisit/images/20170618_155330.jpg?maxwidth=1200&maxheight=1200&autorotate=false",
+    "Canada": "https://images.unsplash.com/photo-1479854851860-18d97e109331?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjExMDk0fQ&auto=format&fit=crop&w=1344&q=80",
+    "India": "https://images.unsplash.com/photo-1564507592333-c60657eea523?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1502&q=80"
+  }
+}


### PR DESCRIPTION
Using a random Unsplash image for each region was easy, but it would frequently result in weird images. This hardcodes a few landmarks/identifying characteristics from each region.