### PR TITLE
Improve wording of submitting events to be less confusing

### DIFF
--- a/components/nav.js
+++ b/components/nav.js
@@ -86,11 +86,11 @@ export default () => {
         <Button
           as="a"
           href="https://airtable.com/shr42MplImeMkHHWP"
-          aria-label="Submit your hackathon"
+          aria-label="Apply to list your hackathon"
           variant="outline"
           sx={{ ml: 'auto', py: 0, px: 2 }}
         >
-          Submit
+          Add your event
         </Button>
         <NavButton
           as="a"


### PR DESCRIPTION
Since we shipped the new site I've gotten an increasing number of questions from organizers asking to submit their event, which leads me to believe the new "submit" wording is not intuitive.

Switching the wording back to the less confusing "Add your event" only kind of breaks on iPhone SE and below, which I think is a worthy price to pay for a more intuitive design, when a vanishingly small number of users are going to hit that quirk of the design. Other suggestions welcome, but I think bottom line for me is that "submit" is not clear enough for users.

iPhone 8:
<img width="388" alt="Screen Shot 2020-02-18 at 23 39 36" src="https://user-images.githubusercontent.com/5403917/74802567-44c58480-52a8-11ea-8579-98baf8dba2d0.png">

iPhone SE:
<img width="328" alt="Screen Shot 2020-02-18 at 23 39 40" src="https://user-images.githubusercontent.com/5403917/74802576-4a22cf00-52a8-11ea-8c73-7b24f8c8ee60.png">
