### PR TITLE
Add space after period

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -61,7 +61,7 @@ export default ({ stats, emailStats, events }) => (
           &nbsp;countries.
         </Text>
         <Text variant="subtitle">
-          Maintained by the <Link href="https://hackclub.com/">Hack Club</Link>{' '}
+          {' '}Maintained by the <Link href="https://hackclub.com/">Hack Club</Link>{' '}
           staff.
         </Text>
       </>


### PR DESCRIPTION
adds space between `countries.` and `Maintained`

<img width="263" alt="Screen Shot 2021-08-09 at 10 51 45 AM" src="https://user-images.githubusercontent.com/72365100/128751113-f8d5eae6-12fd-4d71-b51d-41e84e1422c8.png">
