### PR TITLE
Adapt for increasing number of in-person hackathons

### DIFF
--- a/components/event-card.js
+++ b/components/event-card.js
@@ -69,7 +69,8 @@ const EventCard = ({
           bg: 'snow',
           color: virtual ? 'red' : 'blue',
           fontSize: 'inherit',
-          textShadow: 'none'
+          textShadow: 'none',
+          borderRadius: 5
         }}
       >
         {virtual ? 'Online' : 'In-Person'}
@@ -92,10 +93,9 @@ const EventCard = ({
       <Heading as="h3" itemProp="name" sx={{ fontSize: [3, 4], mt: 2, mb: 3, overflowWrap: "anywhere" }}>
         {name}
       </Heading>
-      <Flex
+      <Box
         as="footer"
         sx={{
-          justifyContent: 'space-between',
           mt: 'auto',
           width: '100%',
           opacity: 0.875
@@ -113,11 +113,11 @@ const EventCard = ({
         >
           {!virtual && (
             <span itemProp="address">
-              {formatAddress(city, state, country, countryCode)}
+              {': '}{formatAddress(city, state, country, countryCode)}
             </span>
           )}
         </Text>
-      </Flex>
+      </Box>
       <Box sx={{ display: 'none' }}>
         <span itemProp="eventAttendanceMode">
           {virtual

--- a/components/event-card.js
+++ b/components/event-card.js
@@ -58,6 +58,23 @@ const EventCard = ({
           }}
         />
       )}
+          
+      <Badge
+        as="span"
+        itemType="VirtualLocation"
+        sx={{
+          position: 'absolute',
+          top: 16,
+          right: 16,
+          bg: 'snow',
+          color: virtual ? 'red' : 'blue',
+          fontSize: 'inherit',
+          textShadow: 'none'
+        }}
+      >
+        {virtual ? 'Online' : 'In-Person'}
+      </Badge>
+
       {logo && (
         <Image
           src={logo}
@@ -94,20 +111,7 @@ const EventCard = ({
           itemScope
           itemType="http://schema.org/Place"
         >
-          {virtual ? (
-            <Badge
-              as="span"
-              itemType="VirtualLocation"
-              sx={{
-                bg: 'white',
-                color: 'blue',
-                fontSize: 'inherit',
-                textShadow: 'none'
-              }}
-            >
-              Online
-            </Badge>
-          ) : (
+          {!virtual && (
             <span itemProp="address">
               {formatAddress(city, state, country, countryCode)}
             </span>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -15,7 +15,7 @@ const App = ({ Component, pageProps }) => (
       as={Head}
       title="Hack Club Hackathons"
       name="Hack Club Hackathons"
-      description="Listing of upcoming high school hackathons around the world."
+      description="Listing of upcoming online and in-person high school hackathons around the world."
       image="https://hackathons.hackclub.com/card.png"
     />
     <NProgress color={theme.colors.primary} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,7 +9,7 @@ import { filter, orderBy, slice, last } from 'lodash'
 import { timeSince, humanizedDateRange } from '../lib/util'
 import { getGroupingData } from '../lib/data'
 
-const title = `Online High School Hackathons in ${new Date().getFullYear()}`
+const title = `High School Hackathons in ${new Date().getFullYear()}`
 const eventsPreview = events =>
   slice(events, 0, 4)
     .map(
@@ -25,7 +25,7 @@ export default ({ stats, emailStats, events }) => (
         <Meta
           as={Head}
           title={title}
-          description={`${title}. A curated list of high school hackathons with ${
+          description={`${title}. A curated list of online and in-person high school hackathons with ${
             events.length
           } events in ${stats.state} states + ${
             stats.country
@@ -34,33 +34,18 @@ export default ({ stats, emailStats, events }) => (
           )}`}
         />
         <Heading as="h1" variant="title" sx={{ color: 'primary' }}>
-          <Text
-            as="span"
-            sx={{
-              color: 'cyan',
-              display: 'inline-block',
-              transition: 'all .25s ease-in-out',
-              ':hover': {
-                WebkitTextStroke: 'currentColor',
-                WebkitTextStrokeWidth: '2px',
-                WebkitTextFillColor: theme => theme.colors.white,
-                textShadow: theme => `0 0 12px ${theme.colors.cyan}`,
-                transform: 'rotate(-4deg) scale(1.025)'
-              }
-            }}
-          >
-            (Online)
-          </Text>{' '}
-          High School Hackathons in {new Date().getFullYear()}
+          High School Hackathons{' '}
+          <Box as="br" sx={{ display: ['none', 'block'] }} /> 
+          in {new Date().getFullYear()}
         </Heading>
-        <Text variant="subtitle" sx={{ my: 3 }}>
+        <Text as='p' variant="subtitle" sx={{ my: 3 }}>
           A curated list of high school hackathons with
           <Box as="br" sx={{ display: ['none', 'block'] }} /> {stats.total}
           &nbsp;events in {stats.state}
           &nbsp;states + {stats.country}
           &nbsp;countries.
         </Text>
-        <Text variant="subtitle">
+        <Text as='p' variant="subtitle">
           {' '}Maintained by the <Link href="https://hackclub.com/">Hack Club</Link>{' '}
           staff.
         </Text>


### PR DESCRIPTION
## Rationale

A bit ago, due to the pandemic, this site was updated to reflect that every hackathon was being hosted online. Now I feel that this landscape has changed, there's already one in-person hackathon on the site and I know of 4 people (including myself) who are organizing in-person hackathons in the near future.

I removed online-only phraseology and updated the card design to better clarify which hackathons are which. In my opinion this can better meet the demands of visitors looking for hackathons because it better visually distinguishes online and in-person ones.  

## Changes

- Added a badge to **every** hackathon card that says whether it's in-person or online, with a unique color for each status
- Removed the text "(Online)" from the main heading
- Updated meta tags to include "online and in-person" for better SEO in the case of visitors specifically looking for either kind of hackathon
- Made very minor changes to paragraph code in the hero (simply changing the tag type) to make the spacing work as I believe the original developer intended it to work

## Screenshot

You can also check the automatic Vercel deployment.

![Screenshot of website](https://doggo.ninja/bCbpUI.png)