### PR TITLE
Make Years grid a single row

### DIFF
--- a/components/years.js
+++ b/components/years.js
@@ -15,7 +15,7 @@ Object.entries(palette).map(([name, bg], i) => {
 })
 
 const Years = ({ showAll = false }) => (
-  <Grid columns={[1, 2, showAll ? 6 : 5]} gap={[3, 4]}>
+  <Grid columns={[1, 2, showAll ? 7 : 6]} gap={[3, 4]}>
     {showAll && (
       <Link href="/" passHref>
         <Card as="a" variant="nav" sx={{ bg: 'elevated', color: 'primary' }}>

--- a/components/years.js
+++ b/components/years.js
@@ -15,7 +15,7 @@ Object.entries(palette).map(([name, bg], i) => {
 })
 
 const Years = ({ showAll = false }) => (
-  <Grid columns={[1, 2, showAll ? 5 : 4]} gap={[3, 4]}>
+  <Grid columns={[1, 2, showAll ? 6 : 5]} gap={[3, 4]}>
     {showAll && (
       <Link href="/" passHref>
         <Card as="a" variant="nav" sx={{ bg: 'elevated', color: 'primary' }}>


### PR DESCRIPTION
I read about this in Lachlan's Technical Transition write-up; relevant excerpt below:
> One task you will want to do is have a 2021 filter page next year. The page itself will be automatically generated if there’s an event in 2021 in the Airtable, but you’ll need to change the columns of the <Grid> in the Years component when 2021 events roll around to [1, 2, showAll ? 6 : 5] for the layout to look its best.
