### PR TITLE
Create reminder email GH action

### DIFF
--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -1,0 +1,16 @@
+name: Send Reminder Emails
+
+on:
+  schedule:
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+
+jobs:
+  send-reminder-emails:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch API Data 📦
+        uses: JamesIves/fetch-api-data-action@releases/v1
+        with:
+          ENDPOINT: https://hackathons.hackclub.com/api/send-reminder
+          CONFIGURATION: '{ "method": "GET", "headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"} }'

--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Fetch API Data 📦
         uses: JamesIves/fetch-api-data-action@releases/v1
         with:
-          ENDPOINT: https://hackathons.hackclub.com/api/send-reminder
+          ENDPOINT: https://hackathons.hackclub.com/api/trigger-reminder
           CONFIGURATION: '{ "method": "GET", "headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"} }'


### PR DESCRIPTION
This PR assumes there's a GET endpoint for triggering email list sending at `/api/send-reminder` & requires an auth bearer token of `secrets.TOKEN`.