### PR TITLE
chore: Remove MLH wording

### DIFF
--- a/components/footer.mdx
+++ b/components/footer.mdx
@@ -1,5 +1,5 @@
 Maintained by [Hack&nbsp;Club](https://hackclub.com/), a nonprofit network of 16K+ high school hackers & coding clubs around the world.
 
-Want to run your own hackathon? Get a bank account at [Hack&nbsp;Club Bank](https://hackclub.com/bank/) & the support of [MLH](https://mlh.io).
+Want to run your own hackathon? Get a bank account at [Hack&nbsp;Club Bank](https://hackclub.com/bank/).
 
 [Events API](/data) – [Open source on GitHub](https://github.com/hackclub/hackathons)


### PR DESCRIPTION
Wording is confusing it makes it seem like in order to run a hackathon you need to go through MLH when most hackathons organized by Hack Clubbers are not affiliated with MLH.