### PR TITLE
Set copyColor of announcement to darkless, irrespective of themes (Fix for issue #303)

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -57,6 +57,7 @@ export default ({ stats, emailStats, events, header }) => (
           href="https://hackclub.com/hackathons/grant/"
           color="primary"
           captionColor="darkless"
+          copyColor="darkless"
         />
       </>
     }


### PR DESCRIPTION
Changed the color of copy in announcement to always be 'darkless'

Fix for #303 