### PR TITLE
Center logo

### DIFF
--- a/components/event-card.js
+++ b/components/event-card.js
@@ -80,7 +80,7 @@ const EventCard = ({
             height: hq ? 200 : 64,
             width: hq ? '100%' : null,
             objectFit: hq ? 'contain' : 'contain',
-            objectPosition: 'left',
+            objectPosition: 'center',
             borderRadius: 'default',
             mt: 'auto'
           }}


### PR DESCRIPTION
Hackathon logos that are not squares appears off center.
![image](https://github.com/hackclub/hackathons/assets/66446458/170e808f-1123-4b00-83d4-c4ba2a45994b)

This PR centers the logos of hackathon cards
![image](https://github.com/hackclub/hackathons/assets/66446458/3bcc47f8-b0fd-4510-815d-a8b006cfd4e8)