### PR TITLE
feat: add hack_club_event to events data

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -48,6 +48,7 @@ export const getEvents = async ({ upcoming } = { upcoming: false }) => {
     virtual: event.modality === MODALITY.VIRTUAL,
     hybrid: event.modality === MODALITY.HYBRID,
     mlhAssociated: false, // This field is deprecated
+    hack_club_event: event.website?.toLowerCase().includes('hackclub.com') ?? false,
     apac: event.apac
   }))
 

--- a/lib/data.js
+++ b/lib/data.js
@@ -48,7 +48,7 @@ export const getEvents = async ({ upcoming } = { upcoming: false }) => {
     virtual: event.modality === MODALITY.VIRTUAL,
     hybrid: event.modality === MODALITY.HYBRID,
     mlhAssociated: false, // This field is deprecated
-    hack_club_event: event.website?.toLowerCase().includes('hackclub.com') ?? false,
+    hack_club_event: event.website ? /^https?:\/\/(.+\.)?hackclub\.com(\/|\?|#|$)/.test(event.website.toLowerCase()) : false,
     apac: event.apac
   }))
 


### PR DESCRIPTION
Does a regex check for if the hackathon website is on hackclub.com, if so hack_club_event will be true, since https://dash.hackathons.hackclub.com/api/v1/hackathons doesn't have that specific data.

closes #322 